### PR TITLE
Add debugging information flag for java compilation

### DIFF
--- a/neoj-builder/Dockerfile
+++ b/neoj-builder/Dockerfile
@@ -8,4 +8,4 @@ WORKDIR /build/files
 
 COPY org.neo.smartcontract.framework.jar /build
 
-ENTRYPOINT ["javac", "-d", "/build/files", "-sourcepath", "/build/files", "-cp", "/build/org.neo.smartcontract.framework.jar"]
+ENTRYPOINT ["javac", "-g", "-d", "/build/files", "-sourcepath", "/build/files", "-cp", "/build/org.neo.smartcontract.framework.jar"]


### PR DESCRIPTION
### Problem
I noticed `neoj` doesn't compile correctly for some class files created with `neoj-builder`. It appears that neoj needs debugging information in the class files.

See https://github.com/neo-project/neo-compiler/issues/79

...

### Solution

Add `-g` flag to `javac` command
...

### Remember

- Bump `VERSION`
- Update `CHANGELOG.md`
- Update `README.md`